### PR TITLE
Update for PHP 5.3.3

### DIFF
--- a/DateTimeImmutable.php
+++ b/DateTimeImmutable.php
@@ -33,9 +33,9 @@ class DateTimeImmutable implements DateTimeInterface {
   public function __construct($time = "now", $object = null) {
     if($object instanceof DateTimeZone){
     	$this->dt = new DateTime($time, $object);
-	  }else{
-  		$this->dt = new DateTime($time);
-	  }
+    }else{
+  	$this->dt = new DateTime($time);
+    }
   }
 
   public function __wakeup() {

--- a/DateTimeImmutable.php
+++ b/DateTimeImmutable.php
@@ -31,7 +31,11 @@ class DateTimeImmutable implements DateTimeInterface {
   private $dt;
 
   public function __construct($time = "now", $object = null) {
-    $this->dt = new DateTime($time, $object);
+    if($object instanceof DateTimeZone){
+    	$this->dt = new DateTime($time, $object);
+	  }else{
+  		$this->dt = new DateTime($time);
+	  }
   }
 
   public function __wakeup() {


### PR DESCRIPTION
DateTime::__construct() expects parameter 2 to be DateTimeZone, null given